### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/fernandobanda071/de6eb2d1-042b-4ee8-89f2-b33035ea91b3/c4ec67c0-a3c7-47d3-9538-264ce93dadce/_apis/work/boardbadge/c995a2cb-86f0-42fe-907b-389edba25620)](https://dev.azure.com/fernandobanda071/de6eb2d1-042b-4ee8-89f2-b33035ea91b3/_boards/board/t/c4ec67c0-a3c7-47d3-9538-264ce93dadce/Microsoft.RequirementCategory)
 # Development Containers
 
 This repository is for the Development Container Specification. You can check out the spec on our website https://containers.dev/ too.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/fernandobanda071/de6eb2d1-042b-4ee8-89f2-b33035ea91b3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.